### PR TITLE
Option "d" now accepts an argument

### DIFF
--- a/src/main/java/com/codingame/gameengine/runner/CommandLineInterface.java
+++ b/src/main/java/com/codingame/gameengine/runner/CommandLineInterface.java
@@ -28,7 +28,7 @@ public class CommandLineInterface {
 			       .addOption("p4", true, "Player 4 command line.")
 			       .addOption("s", false, "Server mode")
 			       .addOption("l", true, "File output for logs")
-			       .addOption("d", false, "Referee initial data");
+			       .addOption("d", true, "Referee initial data");
 
 			CommandLine cmd = new DefaultParser().parse(options, args);
 


### PR DESCRIPTION
The option "d" didn't accept any argument. This bug prevented users from setting a custom seed for the referee.